### PR TITLE
Add ci.yml for Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,31 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  mac-os:
     runs-on: macos-12
+    strategy:
+      matrix:
+        xcode: ["13.4.1","14.0.0-beta"]
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
-      with:
-         xcode-version: '14.0.0-beta'
-    - uses: actions/checkout@v3
-    - name: Build
-      run: swift build -v
-    - name: Run tests
-      run: swift test -v
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode }}
+      - uses: actions/checkout@v3
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test
+        
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        swift: ["5.6","5.7"]
+    container:
+      image: swift:${{ matrix.swift }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        swift: ["5.6","5.7"]
+        swift: ["5.6"]
     container:
       image: swift:${{ matrix.swift }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: ci
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: macos-12
+    steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+         xcode-version: '14.0.0-beta'
+    - uses: actions/checkout@v3
+    - name: Build
+      run: swift build -v
+    - name: Run tests
+      run: swift test -v


### PR DESCRIPTION
closed #8 

I have used specific Xcode beta to get Swift 5.7. However once we support older versions of swift, we have to revisit this. Probably add a matrix with all swift versions.