### PR TITLE
Removes redundant methods that could be handled by generics

### DIFF
--- a/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkKeyedDecoding.swift
@@ -23,20 +23,9 @@ struct MarkKeyedDecoding<Key: CodingKey>: KeyedDecodingContainerProtocol {
         return value == ""
     }
 
-    func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool { try unbox(key) }
-    func decode(_ type: String.Type, forKey key: Key) throws -> String { try unbox(key) }
-    func decode(_ type: Double.Type, forKey key: Key) throws -> Double { try unbox(key) }
-    func decode(_ type: Float.Type, forKey key: Key) throws -> Float { try unbox(key) }
-    func decode(_ type: Int.Type, forKey key: Key) throws -> Int { try unbox(key) }
-    func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 { try unbox(key) }
-    func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 { try unbox(key) }
-    func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 { try unbox(key) }
-    func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 { try unbox(key) }
-    func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt { try unbox(key) }
-    func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 { try unbox(key) }
-    func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 { try unbox(key) }
-    func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 { try unbox(key) }
-    func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 { try unbox(key) }
+    func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable, T: StringInitializable {
+        return try unbox(key)
+    }
 
     func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable {
         switch T.self {

--- a/Sources/MarkCodable/Decoder/MarkSingleValueDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkSingleValueDecoding.swift
@@ -22,20 +22,9 @@ struct MarkSingleValueDecoding: SingleValueDecodingContainer {
         return value == "nil"
     }
 
-    func decode(_ type: Bool.Type) throws -> Bool { try unbox() }
-    func decode(_ type: String.Type) throws -> String { try unbox() }
-    func decode(_ type: Double.Type) throws -> Double { try unbox() }
-    func decode(_ type: Float.Type) throws -> Float { try unbox() }
-    func decode(_ type: Int.Type) throws -> Int { try unbox() }
-    func decode(_ type: Int8.Type) throws -> Int8 { try unbox() }
-    func decode(_ type: Int16.Type) throws -> Int16 { try unbox() }
-    func decode(_ type: Int32.Type) throws -> Int32 { try unbox() }
-    func decode(_ type: Int64.Type) throws -> Int64 { try unbox() }
-    func decode(_ type: UInt.Type) throws -> UInt { try unbox() }
-    func decode(_ type: UInt8.Type) throws -> UInt8 { try unbox() }
-    func decode(_ type: UInt16.Type) throws -> UInt16 { try unbox() }
-    func decode(_ type: UInt32.Type) throws -> UInt32 { try unbox() }
-    func decode(_ type: UInt64.Type) throws -> UInt64 { try unbox() }
+    func decode<T>(_ type: T.Type) throws -> T where T : Decodable, T: StringInitializable {
+        return try unbox()
+    }
 
     func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
         switch T.self {

--- a/Sources/MarkCodable/Decoder/MarkUnkeyedDecoding.swift
+++ b/Sources/MarkCodable/Decoder/MarkUnkeyedDecoding.swift
@@ -43,21 +43,6 @@ struct MarkUnkeyedDecoding: UnkeyedDecodingContainer {
         }
     }
 
-    mutating func decode(_ type: Bool.Type) throws -> Bool { return try unbox() }
-    mutating func decode(_ type: String.Type) throws -> String { return try unbox() }
-    mutating func decode(_ type: Double.Type) throws -> Double { return try unbox() }
-    mutating func decode(_ type: Float.Type) throws -> Float { return try unbox() }
-    mutating func decode(_ type: Int.Type) throws -> Int { return try unbox() }
-    mutating func decode(_ type: Int8.Type) throws -> Int8 { return try unbox() }
-    mutating func decode(_ type: Int16.Type) throws -> Int16 { return try unbox() }
-    mutating func decode(_ type: Int32.Type) throws -> Int32 { return try unbox() }
-    mutating func decode(_ type: Int64.Type) throws -> Int64 { return try unbox() }
-    mutating func decode(_ type: UInt.Type) throws -> UInt { return try unbox() }
-    mutating func decode(_ type: UInt8.Type) throws -> UInt8 { return try unbox() }
-    mutating func decode(_ type: UInt16.Type) throws -> UInt16 { return try unbox() }
-    mutating func decode(_ type: UInt32.Type) throws -> UInt32 { return try unbox() }
-    mutating func decode(_ type: UInt64.Type) throws -> UInt64 { return try unbox() }
-
     mutating func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
         try guardAtEnd()
 

--- a/Sources/MarkCodable/Encoder/MarkKeyedEncoding.swift
+++ b/Sources/MarkCodable/Encoder/MarkKeyedEncoding.swift
@@ -23,60 +23,8 @@ struct MarkKeyedEncoding<Key: CodingKey>: KeyedEncodingContainerProtocol {
         data.encode(key: codingPath + [key], value: "")
     }
 
-    mutating func encode(_ value: Bool, forKey key: Key) throws {
-        data.encode(key: codingPath + [key], value: String(value))
-    }
-
-    mutating func encode(_ value: String, forKey key: Key) throws {
-        data.encode(key: codingPath + [key], value: value)
-    }
-
-    mutating func encode(_ value: Double, forKey key: Key) throws {
-        data.encode(key: codingPath + [key], value: String(value))
-    }
-
-    mutating func encode(_ value: Float, forKey key: Key) throws {
-        data.encode(key: codingPath + [key], value: String(value))
-    }
-
-    mutating func encode(_ value: Int, forKey key: Key) throws {
-        data.encode(key: codingPath + [key], value: String(value))
-    }
-
-    mutating func encode(_ value: Int8, forKey key: Key) throws {
-        data.encode(key: codingPath + [key], value: String(value))
-    }
-
-    mutating func encode(_ value: Int16, forKey key: Key) throws {
-        data.encode(key: codingPath + [key], value: String(value))
-    }
-
-    mutating func encode(_ value: Int32, forKey key: Key) throws {
-        data.encode(key: codingPath + [key], value: String(value))
-    }
-
-    mutating func encode(_ value: Int64, forKey key: Key) throws {
-        data.encode(key: codingPath + [key], value: String(value))
-    }
-
-    mutating func encode(_ value: UInt, forKey key: Key) throws {
-        data.encode(key: codingPath + [key], value: String(value))
-    }
-
-    mutating func encode(_ value: UInt8, forKey key: Key) throws {
-        data.encode(key: codingPath + [key], value: String(value))
-    }
-
-    mutating func encode(_ value: UInt16, forKey key: Key) throws {
-        data.encode(key: codingPath + [key], value: String(value))
-    }
-
-    mutating func encode(_ value: UInt32, forKey key: Key) throws {
-        data.encode(key: codingPath + [key], value: String(value))
-    }
-
-    mutating func encode(_ value: UInt64, forKey key: Key) throws {
-        data.encode(key: codingPath + [key], value: String(value))
+    mutating func encode<T: Encodable & StringInitializable>(_ value: T, forKey key: Key) throws {
+        data.encode(key: codingPath + [key], value: String(describing: value))
     }
 
     mutating func encode<T: Encodable>(_ value: T, forKey key: Key) throws {

--- a/Sources/MarkCodable/Encoder/MarkSingleValueEncoding.swift
+++ b/Sources/MarkCodable/Encoder/MarkSingleValueEncoding.swift
@@ -22,60 +22,8 @@ struct MarkSingleValueEncoding: SingleValueEncodingContainer {
         data.encode(key: codingPath, value: "nil")
     }
 
-    mutating func encode(_ value: Bool) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: String) throws {
-        data.encode(key: codingPath, value: value)
-    }
-
-    mutating func encode(_ value: Double) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: Float) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: Int) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: Int8) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: Int16) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: Int32) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: Int64) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: UInt) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: UInt8) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: UInt16) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: UInt32) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: UInt64) throws {
-        data.encode(key: codingPath, value: String(value))
+    mutating func encode<T>(_ value: T) throws where T : Encodable, T : StringInitializable {
+        data.encode(key: codingPath, value: String(describing: value))
     }
 
     // TODO: Extract this logic into a reusable function

--- a/Sources/MarkCodable/Encoder/MarkUnkeyedEncoding.swift
+++ b/Sources/MarkCodable/Encoder/MarkUnkeyedEncoding.swift
@@ -25,62 +25,6 @@ struct MarkUnkeyedEncoding: UnkeyedEncodingContainer {
         data.encode(key: codingPath, value: "nil")
     }
 
-    mutating func encode(_ value: Bool) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: String) throws {
-        data.encode(key: codingPath, value: value)
-    }
-
-    mutating func encode(_ value: Double) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: Float) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: Int) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: Int8) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: Int16) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: Int32) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: Int64) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: UInt) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: UInt8) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: UInt16) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: UInt32) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
-    mutating func encode(_ value: UInt64) throws {
-        data.encode(key: codingPath, value: String(value))
-    }
-
     mutating func encode<T>(_ value: T) throws where T : Encodable {
         let markEncoding = MarkEncoding(codingPath: codingPath, userInfo: userInfo, to: data)
 


### PR DESCRIPTION
Resolves https://github.com/icanzilb/MarkCodable/issues/12

Some of the encoder/decoder overloads could've been handled with generics as suggested in the issue.